### PR TITLE
Fix a bug with dir path when there is no git repo and refactor comments

### DIFF
--- a/conf.d/venv.fish
+++ b/conf.d/venv.fish
@@ -14,7 +14,7 @@ function __auto_source_venv --on-variable PWD --description "Activate/Deactivate
   if git rev-parse --show-toplevel &>/dev/null
     set gitdir (realpath (git rev-parse --show-toplevel))
   else
-    set gitdir "."
+    set gitdir (pwd)
   end
 
   # find a virtual environment in the git directory

--- a/conf.d/venv.fish
+++ b/conf.d/venv.fish
@@ -10,27 +10,25 @@
 function __auto_source_venv --on-variable PWD --description "Activate/Deactivate virtualenv on directory change"
   status --is-command-substitution; and return
 
-  # Check if we are inside a git directory
+  # Check if we are inside a git repository
   if git rev-parse --show-toplevel &>/dev/null
-    set gitdir (realpath (git rev-parse --show-toplevel))
+    set dir (realpath (git rev-parse --show-toplevel))
   else
-    set gitdir (pwd)
+    set dir (pwd)
   end
 
-  # find a virtual environment in the git directory
-
+  # Find a virtual environment in the directory
   set VENV_DIR_NAMES env .env venv .venv
-  for venv_dir in $gitdir/$VENV_DIR_NAMES
+  for venv_dir in $dir/$VENV_DIR_NAMES
     if test -e "$venv_dir/bin/activate.fish"
       break
     end
   end
 
-
-  # If venv is not activated or a different venv is activated and venv exist.
+  # Activate venv if it was found and not activated before
   if test "$VIRTUAL_ENV" != "$venv_dir" -a -e "$venv_dir/bin/activate.fish"
     source $venv_dir/bin/activate.fish
-  # If venv activated but the current (git) dir has no venv.
+  # Deactivate venv if it is activated but the directory doesn't exist
   else if not test -z "$VIRTUAL_ENV" -o -e "$venv_dir"
     deactivate
   end


### PR DESCRIPTION
### What I've done:

1. Fixed a bug with the directory path when there is no git repository
2. Refactored comments

### Description of the bug

Since `$VIRTUAL_ENV` is stored as an absolute path, we must also use an absolute path. Currently, we are using `"."` and this leads to the following result:
![CleanShot 2023-11-23 at 19 53 02@2x](https://github.com/nakulj/auto-venv/assets/62479571/70d18f5a-d4ce-4b42-a17d-5eccdbe0613a)

But when we use `pwd` instead, it compares them correctly:
![CleanShot 2023-11-23 at 19 51 28@2x](https://github.com/nakulj/auto-venv/assets/62479571/1a8bc84b-67dd-4851-90ab-c2660ccf2b10)

Of course, this is not a critical error, but I think you shouldn't run `source venv/bin/activate.fish` more than once.

### Description of other changes

I also changed the variable name from `gitdir' to `dir' because it can store not only the git repository. And I changed the comments to make them more clear.
