### PR TITLE
Search both current directory and repo root

### DIFF
--- a/conf.d/venv.fish
+++ b/conf.d/venv.fish
@@ -10,18 +10,20 @@
 function __auto_source_venv --on-variable PWD --description "Activate/Deactivate virtualenv on directory change"
   status --is-command-substitution; and return
 
-  # Check if we are inside a git repository
+  # Searched directories are the current directory, and the root of the current git repo if applicable
   if git rev-parse --show-toplevel &>/dev/null
-    set dir (realpath (git rev-parse --show-toplevel))
+    set dirs (realpath (git rev-parse --show-toplevel))
   else
-    set dir (pwd)
+    set dirs -a (pwd)
   end
 
-  # Find a virtual environment in the directory
+  # Find a virtual environment in the directories
   set VENV_DIR_NAMES env .env venv .venv
-  for venv_dir in $dir/$VENV_DIR_NAMES
-    if test -e "$venv_dir/bin/activate.fish"
-      break
+  for dir in $dirs
+    for venv_dir in $dir/$VENV_DIR_NAMES
+        if test -e "$venv_dir/bin/activate.fish"
+            break
+        end
     end
   end
 


### PR DESCRIPTION
This cover the use case where the current directory is inside a repo, the virtual environment being in the current directory, but not at the root of the repository. This is a common case in companies following monorepo pattern, where all modules of a system are in the same repo, and where dev would work in one of those module directories, and create virtual environment there.