### PR TITLE
feat: allow silencing outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,10 @@ The plugin looks for virtual environments in the following directories:
 - `.venv/`
 
 If you're in a git repository, it will look for these directories at the repository root.
+
+
+## Configuration
+
+Configuration can be done by setting environment variables:
+
+* `AUTO_VENV_SILENT`: Auto-venv outputs the activated virtual environment by default, and indicates when the environment was deactivated. When `AUTO_VENV_SILENT` is set, this output is omitted.

--- a/conf.d/venv.fish
+++ b/conf.d/venv.fish
@@ -12,6 +12,10 @@
 # Global flag to track if we're in the middle of handling venv
 set -g __VENV_HANDLING 0
 
+function __venv_output
+    set -q AUTO_VENV_SILENT || echo $argv
+end
+
 function __safe_activate_venv
     # Save current state
     set -l old_path $PATH
@@ -86,7 +90,7 @@ function __auto_source_venv --on-variable PWD --description "Activate/Deactivate
     if test -n "$venv_dir" -a "$VIRTUAL_ENV" != "$venv_dir" -a -e "$venv_dir/bin/activate.fish"
         # Activate venv if it was found and not activated before
         __safe_activate_venv "$venv_dir/bin/activate.fish"
-        echo "Activated virtualenv: $venv_dir ($(which python))"
+        __venv_output "Activated virtualenv: $venv_dir ($(which python))"
     else if test -n "$VIRTUAL_ENV" -a -z "$venv_dir"
         # Deactivate venv if it is activated but we're no longer in a directory with a venv
         # Save PATH before deactivation
@@ -108,7 +112,7 @@ function __auto_source_venv --on-variable PWD --description "Activate/Deactivate
             set -e VIRTUAL_ENV_PROMPT
             set -gx PATH $old_path
         end
-        echo "Deactivated virtualenv"
+        __venv_output "Deactivated virtualenv"
     end
 
     set -g __VENV_HANDLING 0


### PR DESCRIPTION
Some prompts show the currently active virtual environment for Python already.
The output, which virtual environment was enabled or disabled can lead to clutter
in the output.

By setting the env variable `AUTO_VENV_SILENT`, these outputs are omitted.

Resolves #9
