### PR TITLE
Fix deactivate command error in fish shell

### DIFF
--- a/conf.d/venv.fish
+++ b/conf.d/venv.fish
@@ -24,13 +24,13 @@ function __venv --argument-names dir
 end
 
 function __handle_venv_activation --argument-names dir
-  set -l venv_dir (__venv $dir); or begin
-    # no virtual env found, deactivate any existing virtual env 
+    set -l venv_dir (__venv $dir); or begin
+        # no virtual env found, deactivate any existing virtual env 
         if set -q VIRTUAL_ENV; and functions -q deactivate
             deactivate
         end
-    return
-  end
+        return
+    end
 
     if test "$VIRTUAL_ENV" != "$venv_dir"
         source "$venv_dir/bin/activate.fish"

--- a/conf.d/venv.fish
+++ b/conf.d/venv.fish
@@ -1,6 +1,5 @@
 # Based on https://gist.github.com/tommyip/cf9099fa6053e30247e5d0318de2fb9e
 
-
 # Based on https://gist.github.com/bastibe/c0950e463ffdfdfada7adf149ae77c6f
 # Changes:
 # * Instead of overriding cd, we detect directory change. This allows the script to work
@@ -9,38 +8,38 @@
 
 # where to look for virtual environments
 function __venv_base
-  git rev-parse --show-toplevel 2>/dev/null; or pwd
+    git rev-parse --show-toplevel 2>/dev/null; or pwd
 end
 
 # find the virtualenv, whatever it is called
 function __venv --argument-names dir
-  set VENV_DIR_NAMES env .env venv .venv
-  for venv_dir in $dir/$VENV_DIR_NAMES
-    if test -e "$venv_dir/bin/activate.fish"
-      echo "$venv_dir"
-      return
+    set VENV_DIR_NAMES env .env venv .venv
+    for venv_dir in $dir/$VENV_DIR_NAMES
+        if test -e "$venv_dir/bin/activate.fish"
+            echo "$venv_dir"
+            return
+        end
     end
-  end
-  return 1
+    return 1
 end
 
 function __handle_venv_activation --argument-names dir
-  set -l venv_dir (__venv $dir); or begin
-    # no virtual env found, deactivate any existing virtual env 
-    if set -q VIRTUAL_ENV; and functions -q deactivate
-    deactivate
-  end
-    return
-  end
+    set -l venv_dir (__venv $dir); or begin
+        # no virtual env found, deactivate any existing virtual env 
+        if set -q VIRTUAL_ENV; and functions -q deactivate
+            deactivate
+        end
+        return
+    end
 
-  if test "$VIRTUAL_ENV" != "$venv_dir"
-    source "$venv_dir/bin/activate.fish"
-  end
+    if test "$VIRTUAL_ENV" != "$venv_dir"
+        source "$venv_dir/bin/activate.fish"
+    end
 end
 
 function __auto_source_venv --on-variable PWD --description "Activate/Deactivate virtualenv on directory change"
-  status --is-command-substitution; and return
-  __handle_venv_activation (__venv_base)
+    status --is-command-substitution; and return
+    __handle_venv_activation (__venv_base)
 end
 
 __auto_source_venv

--- a/conf.d/venv.fish
+++ b/conf.d/venv.fish
@@ -27,7 +27,9 @@ end
 function __handle_venv_activation --argument-names dir
   set -l venv_dir (__venv $dir); or begin
     # no virtual env found, deactivate any existing virtual env 
-    set -q VIRTUAL_ENV; and deactivate
+    if set -q VIRTUAL_ENV; and functions -q deactivate
+    deactivate
+  end
     return
   end
 

--- a/tests/venv.test.fish
+++ b/tests/venv.test.fish
@@ -3,16 +3,16 @@ source (dirname (status -f))/../conf.d/venv.fish
 set tmp (mktemp -d)
 
 function deactivate
-  echo "deactivated"
+    echo deactivated
 end
 
 function source
-  if string match -q '*activate.fish' $argv[1]
-    set -gx VIRTUAL_ENV (string replace -r '/bin/activate\.fish$' '' $argv)
-    echo "sourced $argv"
-    return
-  end
-  builtin source $argv
+    if string match -q '*activate.fish' $argv[1]
+        set -gx VIRTUAL_ENV (string replace -r '/bin/activate\.fish$' '' $argv)
+        echo "sourced $argv"
+        return
+    end
+    builtin source $argv
 end
 
 # __venv_base tests
@@ -22,14 +22,12 @@ end
   __venv_base
 ) -ef $tmp
 
-
 @test "returns git root at git root" (
   git init $tmp/git_repo > /dev/null
   cd git_repo
   __venv_base
   rm -rf $tmp/git_repo
 ) -ef "$tmp/git_repo"
-
 
 @test "returns git root inside git repo" (
   git init $tmp/git_repo > /dev/null
@@ -66,7 +64,7 @@ end
   __venv $tmp/no_venv_dir >/dev/null
   echo $status
   rm -rf $tmp/no_venv_dir
-) = '1'
+) = 1
 
 @test "pass if a virtual env found" (
   mkdir -p $tmp/venv_dir/venv/bin
@@ -74,11 +72,9 @@ end
   __venv $tmp/venv_dir >/dev/null
   echo $status
   rm -rf $tmp/venv_dir
-) = '0'
+) = 0
 
 # __handle_venv_activation tests
-
-
 
 @test "new environment is activated" (
   mkdir -p $tmp/venv_dir/venv/bin
@@ -87,7 +83,6 @@ end
   rm -rf $tmp/venv_dir
   set -e VIRTUAL_ENV
 ) = "sourced $tmp/venv_dir/venv/bin/activate.fish"
-
 
 @test "same environment is not re-activated" (
   mkdir -p $tmp/venv_dir/venv/bin
@@ -110,7 +105,7 @@ end
   rm -rf $tmp/a
   rm -rf $tmp/b
   set -e VIRTUAL_ENV
-)  = "sourced $tmp/a/venv/bin/activate.fish
+) = "sourced $tmp/a/venv/bin/activate.fish
 sourced $tmp/b/venv/bin/activate.fish"
 
 @test "environment is deactivated" (


### PR DESCRIPTION
I get next issue. Probable the same as https://github.com/nakulj/auto-venv/issues/18#issue-4308208870)
```
fish: Unknown command: deactivate
~/.config/fish/conf.d/venv.fish (line 30):
    set -q VIRTUAL_ENV; and deactivate
                            ^~~~~~~~~^
in function '__handle_venv_activation' with arguments '<path-to-current-dir>'
        called on line 41 of file ~/.config/fish/conf.d/venv.fish
in function '__auto_source_venv'
        called on line 44 of file ~/.config/fish/conf.d/venv.fish
from sourcing file ~/.config/fish/conf.d/venv.fish
        called on line 244 of file embedded:config.fish
from sourcing file embedded:config.fish
        called during startup 
```

Now script checks if there is deactivate function before calling it
